### PR TITLE
Allow inputs to be files

### DIFF
--- a/tests/test_alto_tools.py
+++ b/tests/test_alto_tools.py
@@ -4,8 +4,10 @@ import sys
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 
+import collections
 import os
 import re
+import tempfile
 
 
 import alto_tools
@@ -28,3 +30,27 @@ def test_alto_text(capsys):
     captured = capsys.readouterr()
     assert re.search (r'„Bunte Blätter“', captured.out)
     assert re.search (r'Stille Gedanken', captured.out)
+
+def test_walker():
+    def create_empty_file(fn):
+        open(fn, 'a').close()
+
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        # Create some test files
+        create_empty_file(os.path.join(tmpdirname, 'test1.xml'))
+        create_empty_file(os.path.join(tmpdirname, 'test2.xml'))
+        create_empty_file(os.path.join(tmpdirname, 'this-should-not-be-returned'))
+
+        # Create a list of inputs
+        inputs = [
+                os.path.join(tmpdirname, 'test1.xml'),  # Note that this also is in tmpdirname
+                tmpdirname
+        ]
+        fnfilter = lambda fn: fn.endswith('.xml')
+        expected = [
+                os.path.join(tmpdirname, 'test1.xml'),
+                os.path.join(tmpdirname, 'test1.xml'),  # second instance from tmpdirname
+                os.path.join(tmpdirname, 'test2.xml')
+                # NOT 'this-should-not-be-returned'
+        ]
+        assert collections.Counter(alto_tools.walker(inputs, fnfilter)) == collections.Counter(expected)


### PR DESCRIPTION
Allow inputs to be files or directories. Directories are walked and filtered for XML files, as before.

Fixes #2.