### PR TITLE
Fail gracefully on Python 2

### DIFF
--- a/alto_tools.py
+++ b/alto_tools.py
@@ -527,6 +527,10 @@ def walker(inputs, fnfilter=lambda fn: True):
 
 
 def main():
+    if sys.version_info < (3, 0):
+        sys.stdout.write('Python 3 is required.\n')
+        sys.exit(-1)
+
     args = parse_arguments()
     if not len(sys.argv) > 2:
         sys.stdout.write('\nNo operation specified, ')


### PR DESCRIPTION
On Python 2, the script fails with an obscure error message because open() does not have an  `encoding` parameter yet. Fail more gracefully by giving a meaningful error message early on Python 2.