### PR TITLE
edit typo in usage info

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,15 +8,15 @@
 
 * extract UTF-8 text content from ALTO file  
 
-  `python3 alto-tools.py alto.xml -t`
+  `python3 alto_tools.py alto.xml -t`
 
 * extract page OCR confidence score from ALTO file  
 
-  `python3 alto-tools.py alto.xml -c`
+  `python3 alto_tools.py alto.xml -c`
 
 * extract bounding boxes of illustrations from ALTO file  
 
-  `python3 alto-tools.py alto.xml -l`
+  `python3 alto_tools.py alto.xml -l`
 
 ## Planned
 


### PR DESCRIPTION
There was a typo in usage of `alto_tools` (it was `alto-tools` in README.md). Fixed it. 