### PR TITLE
Fix `-x` and `-e` command line argument parser configuration (#28)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,3 +1,5 @@
+---
+
 name: tests
 
 on: [push]
@@ -7,18 +9,30 @@ jobs:
 
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version:
+          - 3.8
+          - 3.9
+          - '3.10'
+          - 3.11
+          - 3.12
+          - 3.13
 
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Upgrade pip
-        run: python3 -m pip install --upgrade pip
+        run: python -m pip install --upgrade pip
+      - name: Install dependencies
+        run: pip install -e '.[dev]'
+      - name: Run tests
+        run: >-
+          pytest --cov=src/ --cov-report term-missing --doctest-modules tests
       - name: Build package
         run: python3 -m pip install --upgrade build && python3 -m build
-      - name: Run tests
-        run: python3 -m pip install --upgrade pytest && pytest tests/test_alto_tools.py
+
+...

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,16 @@ dependencies = [
     # none
 ]
 
+[project.optional-dependencies]
+dev = [
+  'black',
+  'pytest-cov',
+]
+
+[tool.setuptools.packages.find]
+where = ['src']
+
+
 [project.scripts]
 alto-tools = "alto_tools.alto_tools:main"
 

--- a/src/alto_tools/alto_tools.py
+++ b/src/alto_tools/alto_tools.py
@@ -238,7 +238,6 @@ def parse_arguments():
     parser.add_argument(
         "-x",
         "--xml-encoding",
-        action="store_true",
         default=None,
         dest="xml_encoding",
         help="XML encoding",

--- a/src/alto_tools/alto_tools.py
+++ b/src/alto_tools/alto_tools.py
@@ -245,7 +245,6 @@ def parse_arguments():
     parser.add_argument(
         "-e",
         "--file-encoding",
-        action="store_true",
         default="UTF-8",
         dest="file_encoding",
         help="file encoding",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -18,11 +18,11 @@ def argv(args: str) -> List[str]:
 
 @pytest.fixture
 def latin_encoded_input_file_name() -> Iterable[str]:
-    with open('tests/data/PPN720183197-PHYS_0004.xml') as f:
+    with open("tests/data/PPN720183197-PHYS_0004.xml") as f:
         xml = f.read()
     with tempfile.TemporaryDirectory() as tmpdir:
-        fn = os.path.join(tmpdir, 'iso8859.xml')
-        with open(fn, 'w+', encoding='iso-8859-1', errors='replace') as f:
+        fn = os.path.join(tmpdir, "iso8859.xml")
+        with open(fn, "w+", encoding="iso-8859-1", errors="replace") as f:
             f.write(xml)
         yield fn
 
@@ -32,7 +32,7 @@ def test_single_file_xml_encoding(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     fn = latin_encoded_input_file_name
-    sys.argv = argv(f'-t -x iso8859-1 {fn}')
+    sys.argv = argv(f"-t -x iso8859-1 {fn}")
     alto_tools.main()
     assert "Stille Gedanken" in capsys.readouterr().out
 
@@ -42,6 +42,6 @@ def test_single_file_file_encoding(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     fn = latin_encoded_input_file_name
-    sys.argv = argv(f'-t -e iso8859-1 {fn}')
+    sys.argv = argv(f"-t -e iso8859-1 {fn}")
     alto_tools.main()
     assert "Stille Gedanken" in capsys.readouterr().out

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -17,7 +17,7 @@ def argv(args: str) -> List[str]:
 
 
 @pytest.fixture
-def latin_encoded_input_file_name() -> Iterable[str]:
+def latin1_input_file_path() -> Iterable[str]:
     with open("tests/data/PPN720183197-PHYS_0004.xml") as f:
         xml = f.read()
     with tempfile.TemporaryDirectory() as tmpdir:
@@ -28,20 +28,20 @@ def latin_encoded_input_file_name() -> Iterable[str]:
 
 
 def test_single_file_xml_encoding(
-    latin_encoded_input_file_name: str,
+    latin1_input_file_path: str,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    fn = latin_encoded_input_file_name
+    fn = latin1_input_file_path
     sys.argv = argv(f"-t -x iso8859-1 {fn}")
     alto_tools.main()
     assert "Stille Gedanken" in capsys.readouterr().out
 
 
 def test_single_file_file_encoding(
-    latin_encoded_input_file_name: str,
+    latin1_input_file_path: str,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    fn = latin_encoded_input_file_name
+    fn = latin1_input_file_path
     sys.argv = argv(f"-t -e iso8859-1 {fn}")
     alto_tools.main()
     assert "Stille Gedanken" in capsys.readouterr().out

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,28 @@
+import os
+import sys
+import tempfile
+from typing import List
+
+import pytest
+
+from alto_tools import alto_tools
+
+
+def argv(args: str) -> List[str]:
+    """
+    >>> argv('-c file')
+    ['alto-tools', '-c', 'file']
+    """
+    return ["alto-tools"] + args.split()
+
+
+def test_single_file_xml_encoding(capsys: pytest.CaptureFixture[str]) -> None:
+    with open('tests/data/PPN720183197-PHYS_0004.xml') as f:
+        xml = f.read()
+    with tempfile.TemporaryDirectory() as tmpdir:
+        fn = os.path.join(tmpdir, 'iso8859.xml')
+        with open(fn, 'w+', encoding='iso-8859-1', errors='replace') as f:
+            f.write(xml)
+        sys.argv = argv(f'-t -x iso8859-1 {fn}')
+        alto_tools.main()
+    assert "Stille Gedanken" in capsys.readouterr().out


### PR DESCRIPTION
Removed the presumably erroneously added `action="store_true"` parameter from the argument parser's `add_argument` calls for configuration of the `--xml-encoding` and `--file-encoding` arguments. This enables passing an input file encoding like e.g.:

```bash
alto-tools -t iso8859.xml -e iso8859-1
```

...or

```bash
alto-tools -t iso8859.xml -x iso8859-1
```

...(both assuming the input file `iso8859.xml` is encoded in latin1).

Fixes #28 