### PR TITLE
Fix text HYP

### DIFF
--- a/src/alto_tools/alto_tools.py
+++ b/src/alto_tools/alto_tools.py
@@ -67,27 +67,21 @@ def alto_text(xml, xmlns):
     if isinstance(sys.stdout, io.TextIOWrapper) and sys.stdout.encoding != "UTF-8":
         sys.stdout = codecs.getwriter("utf-8")(sys.stdout.buffer, "strict")
     # Find all <TextLine> elements
-    for lines in xml.iterfind(".//{%s}TextLine" % xmlns):
+    for line in xml.iterfind(".//{%s}TextLine" % xmlns):
         # New line after every <TextLine> element
         sys.stdout.write("\n")
         # Find all <String> elements
-        for line in lines.findall("{%s}String" % xmlns):
-            # Check if there are no hyphenated words
-            if "SUBS_CONTENT" not in line.attrib and "SUBS_TYPE" not in line.attrib:
-                # Get value of attribute @CONTENT from all <String> elements
-                text = line.attrib.get("CONTENT") + " "
-            else:
-                #  Handling of hyphenation to avoid duplicates, see
-                #  https://github.com/cneud/alto-tools/issues/16
-                if "HypPart1" in line.attrib.get("SUBS_TYPE"):
-                    # Get the first part of the hyphenated word from @CONTENT
-                    # (instead of using @SUBS_CONTENT)
-                    if "HypPart1" in line.attrib.get("SUBS_TYPE"):
-                        text = line.attrib.get("CONTENT")
-                    # Concatenate second part of the hyphenated word from @CONTENT
-                    if "HypPart2" in line.attrib.get("SUBS_TYPE"):
-                        text = line.attrib.get("CONTENT") + " "
-            sys.stdout.write(text)
+        # Do not rely on interspersed <SP> elements
+        # https://github.com/altoxml/schema/issues/54
+        text = ""
+        for word in line.findall("{%s}String" % xmlns):
+            if text:
+                text += " "
+            # Get value of attribute @CONTENT
+            text += word.attrib.get("CONTENT")
+        for hyp in line.findall("{%s}HYP" % xmlns):
+            text += hyp.attrib.get("CONTENT")
+        sys.stdout.write(text)
 
 
 def alto_illustrations(alto, xml, xmlns):

--- a/src/alto_tools/alto_tools.py
+++ b/src/alto_tools/alto_tools.py
@@ -80,7 +80,10 @@ def alto_text(xml, xmlns):
             # Get value of attribute @CONTENT
             text += word.attrib.get("CONTENT")
         for hyp in line.findall("{%s}HYP" % xmlns):
-            text += hyp.attrib.get("CONTENT")
+            #text += hyp.attrib.get("CONTENT")
+            # use plain ASCII hyphen-minus instead of annotated hyphen
+            # (which could be soft-hyphen, historical forms etc.)
+            text += "-"
         sys.stdout.write(text)
 
 

--- a/src/alto_tools/alto_tools.py
+++ b/src/alto_tools/alto_tools.py
@@ -272,6 +272,12 @@ def parse_arguments():
         help="extract statistical information",
     )
     parser.add_argument(
+        "--paragraph-break",
+        default="\n",
+        type=lambda x: x.encode('utf-8').decode('unicode_escape'),
+        help="for --text, insert this string between blocks (accepts Unicode escapes)",
+    )
+    parser.add_argument(
         "-H",
         "--dehyphenate",
         action="store_true",
@@ -391,7 +397,7 @@ def main() -> None:
             if args.confidence:
                 confidence_sum += alto_confidence(alto, xml, xmlns)
             if args.text:
-                alto_text(xml, xmlns, dehyphenate=args.dehyphenate, detect_hyphens=args.detect_hyphens)
+                alto_text(xml, xmlns, dehyphenate=args.dehyphenate, detect_hyphens=args.detect_hyphens, pb=args.paragraph_break)
             if args.illustrations:
                 alto_illustrations(alto, xml, xmlns)
             if args.graphics:

--- a/src/alto_tools/alto_tools.py
+++ b/src/alto_tools/alto_tools.py
@@ -67,7 +67,26 @@ def alto_text(xml, xmlns, dehyphenate=False, detect_hyphens="", pb="\n", lb="\n"
     if isinstance(sys.stdout, io.TextIOWrapper) and sys.stdout.encoding != "UTF-8":
         sys.stdout = codecs.getwriter("utf-8")(sys.stdout.buffer, "strict")
     # Find all <TextBlock> elements
-    for block in xml.iterfind(".//{%s}TextBlock" % xmlns):
+    blocks = list(xml.iterfind(".//{%s}TextBlock" % xmlns))
+    blocks = {block.get("ID"): block for block in blocks}
+    if (readingorder := xml.find(".//{%s}ReadingOrder" % xmlns)) is not None:
+        group = (readingorder.find("{%s}OrderedGroup" % xmlns) or
+                 readingorder.find("{%s}UnorderedGroup" % xmlns))
+        order = [groupref.get("REF") for groupref in group.iter("*") if "REF" in groupref.attrib]
+        # FIXME: ALTO ReadingOrder @REF can also target TextLine and String
+        # adding TextLine and String elements to block list is not sufficient though:
+        # we need to iterate over lowest-level sequence below...
+        assert all(block_id in blocks for block_id in order), "ReadingOrder references below block level currently not supported"
+    elif any(block.get("IDNEXT") for block in blocks.values()):
+        pairs = {block_id: block.get("IDNEXT") for block_id, block in blocks.items()}
+        block = next(block for block in pairs if block not in pairs.values())
+        order = [block]
+        while block := pairs.get(block, None):
+            order.append(block)
+    else:
+        order = list(blocks.keys())
+    for block_id in order:
+        block = blocks[block_id]
         sys.stdout.write(pb)
         wb = ""
         # Find all <TextLine> elements

--- a/src/alto_tools/alto_tools.py
+++ b/src/alto_tools/alto_tools.py
@@ -61,7 +61,7 @@ def alto_parse(alto, **kargs):
         )
 
 
-def alto_text(xml, xmlns, dehyphenate=False, pb="\n", lb="\n"):
+def alto_text(xml, xmlns, dehyphenate=False, detect_hyphens="", pb="\n", lb="\n"):
     """Extract text content from ALTO xml file"""
     # Ensure use of UTF-8
     if isinstance(sys.stdout, io.TextIOWrapper) and sys.stdout.encoding != "UTF-8":
@@ -69,11 +69,12 @@ def alto_text(xml, xmlns, dehyphenate=False, pb="\n", lb="\n"):
     # Find all <TextBlock> elements
     for block in xml.iterfind(".//{%s}TextBlock" % xmlns):
         sys.stdout.write(pb)
+        wb = ""
         # Find all <TextLine> elements
         for line in block.iterfind(".//{%s}TextLine" % xmlns):
             # New line after every <TextLine> element
             if dehyphenate:
-                sys.stdout.write(" ")
+                sys.stdout.write(wb)
             else:
                 sys.stdout.write(lb)
             text = ""
@@ -95,9 +96,18 @@ def alto_text(xml, xmlns, dehyphenate=False, pb="\n", lb="\n"):
                     "HypPart1" in word.attrib.get("SUBS_TYPE")):
                     # Get the annotated dehyphenated value
                     text += word.attrib.get("SUBS_CONTENT")
+                    wb = ""
+                elif (word is words[-1] and dehyphenate and
+                      detect_hyphens and
+                      any(word.attrib.get("CONTENT").endswith(hyphen)
+                          for hyphen in detect_hyphens)):
+                    # Omit the final character
+                    text += word.attrib.get("CONTENT")[:-1]
+                    wb = ""
                 else:
                     # Get value of attribute @CONTENT
                     text += word.attrib.get("CONTENT")
+                    wb = " "
             hyp = line.find("{%s}HYP" % xmlns)
             if hyp is not None and not dehyphenate:
                 #text += hyp.attrib.get("CONTENT")
@@ -265,7 +275,12 @@ def parse_arguments():
         "-H",
         "--dehyphenate",
         action="store_true",
-        help="for text, remove newlines and hyphens",
+        help="for --text, remove newlines and hyphens",
+    )
+    parser.add_argument(
+        "--detect-hyphens",
+        default="",
+        help="for --text --dehyphenate, also interprete these characters as hyphen at EOL",
     )
     parser.add_argument(
         "-x",
@@ -376,7 +391,7 @@ def main() -> None:
             if args.confidence:
                 confidence_sum += alto_confidence(alto, xml, xmlns)
             if args.text:
-                alto_text(xml, xmlns, dehyphenate=args.dehyphenate)
+                alto_text(xml, xmlns, dehyphenate=args.dehyphenate, detect_hyphens=args.detect_hyphens)
             if args.illustrations:
                 alto_illustrations(alto, xml, xmlns)
             if args.graphics:

--- a/src/alto_tools/alto_tools.py
+++ b/src/alto_tools/alto_tools.py
@@ -61,30 +61,50 @@ def alto_parse(alto, **kargs):
         )
 
 
-def alto_text(xml, xmlns):
+def alto_text(xml, xmlns, dehyphenate=False, pb="\n", lb="\n"):
     """Extract text content from ALTO xml file"""
     # Ensure use of UTF-8
     if isinstance(sys.stdout, io.TextIOWrapper) and sys.stdout.encoding != "UTF-8":
         sys.stdout = codecs.getwriter("utf-8")(sys.stdout.buffer, "strict")
-    # Find all <TextLine> elements
-    for line in xml.iterfind(".//{%s}TextLine" % xmlns):
-        # New line after every <TextLine> element
-        sys.stdout.write("\n")
-        # Find all <String> elements
-        # Do not rely on interspersed <SP> elements
-        # https://github.com/altoxml/schema/issues/54
-        text = ""
-        for word in line.findall("{%s}String" % xmlns):
-            if text:
-                text += " "
-            # Get value of attribute @CONTENT
-            text += word.attrib.get("CONTENT")
-        for hyp in line.findall("{%s}HYP" % xmlns):
-            #text += hyp.attrib.get("CONTENT")
-            # use plain ASCII hyphen-minus instead of annotated hyphen
-            # (which could be soft-hyphen, historical forms etc.)
-            text += "-"
-        sys.stdout.write(text)
+    # Find all <TextBlock> elements
+    for block in xml.iterfind(".//{%s}TextBlock" % xmlns):
+        sys.stdout.write(pb)
+        # Find all <TextLine> elements
+        for line in block.iterfind(".//{%s}TextLine" % xmlns):
+            # New line after every <TextLine> element
+            if dehyphenate:
+                sys.stdout.write(" ")
+            else:
+                sys.stdout.write(lb)
+            text = ""
+            # Find all <String> elements
+            # Do not rely on interspersed <SP> elements
+            # https://github.com/altoxml/schema/issues/54
+            words = list(line.findall("{%s}String" % xmlns))
+            for word in words:
+                if word is words[0]:
+                    if (dehyphenate and
+                        word.attrib.get("SUBS_TYPE") and
+                        "HypPart2" in word.attrib.get("SUBS_TYPE")):
+                        continue # skip 2nd part
+                else:
+                    text += " "
+                if (word is words[-1] and dehyphenate and
+                    word.attrib.get("SUBS_TYPE") and
+                    word.attrib.get("SUBS_CONTENT") and
+                    "HypPart1" in word.attrib.get("SUBS_TYPE")):
+                    # Get the annotated dehyphenated value
+                    text += word.attrib.get("SUBS_CONTENT")
+                else:
+                    # Get value of attribute @CONTENT
+                    text += word.attrib.get("CONTENT")
+            hyp = line.find("{%s}HYP" % xmlns)
+            if hyp is not None and not dehyphenate:
+                #text += hyp.attrib.get("CONTENT")
+                # use plain ASCII hyphen-minus instead of annotated hyphen
+                # (which could be soft-hyphen, historical forms etc.)
+                text += "-"
+            sys.stdout.write(text)
 
 
 def alto_illustrations(alto, xml, xmlns):
@@ -187,8 +207,8 @@ def parse_arguments():
     parser = argparse.ArgumentParser(
         description="ALTO Tools: simple tools for performing various operations on ALTO xml files",
         add_help=True,
-        prog="alto_tools.py",
-        usage="python %(prog)s INPUT [option]",
+        prog="alto-tools",
+        usage="%(prog)s INPUT [option]",
     )
     parser.add_argument(
         "INPUT", nargs="+", help="path to ALTO file or directory containing ALTO files"
@@ -240,6 +260,12 @@ def parse_arguments():
         default=False,
         dest="statistics",
         help="extract statistical information",
+    )
+    parser.add_argument(
+        "-H",
+        "--dehyphenate",
+        action="store_true",
+        help="for text, remove newlines and hyphens",
     )
     parser.add_argument(
         "-x",
@@ -350,7 +376,7 @@ def main() -> None:
             if args.confidence:
                 confidence_sum += alto_confidence(alto, xml, xmlns)
             if args.text:
-                alto_text(xml, xmlns)
+                alto_text(xml, xmlns, dehyphenate=args.dehyphenate)
             if args.illustrations:
                 alto_illustrations(alto, xml, xmlns)
             if args.graphics:

--- a/tests/test_alto_tools.py
+++ b/tests/test_alto_tools.py
@@ -26,6 +26,18 @@ def test_alto_text(capsys):
     assert re.search(r"Stille Gedanken", captured.out)
 
 
+def test_alto_text_hyp(capsys):
+    f = open(os.path.join(datadir, "PPN750717092-00000780.ocr.xml"), "r", encoding="UTF8")
+    _, xml, xmlns = alto_tools.alto_parse(f)
+
+    alto_tools.alto_text(xml, xmlns)
+    captured = capsys.readouterr()
+    # hyphen-minus introduced
+    assert re.search(r"Ventilations-\nschachtes", captured.out)
+    # hyphen-minus contained
+    assert re.search(r"Rathans-\nhalle", captured.out)
+
+
 def create_empty_file(fn: str) -> None:
     with open(fn, "a"):
         ...

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -20,7 +20,7 @@ def argv(args: str) -> List[str]:
 
 @pytest.fixture
 def latin1_input_file_path() -> Iterable[str]:
-    with open("tests/data/PPN720183197-PHYS_0004.xml") as f:
+    with open(os.path.join(datadir, "PPN720183197-PHYS_0004.xml")) as f:
         xml = f.read()
     with tempfile.TemporaryDirectory() as tmpdir:
         fn = os.path.join(tmpdir, "iso8859.xml")
@@ -64,13 +64,13 @@ def test_invalid_input_file(capsys: pytest.CaptureFixture[str]) -> None:
 
 
 def test_single_file_confidence(capsys: pytest.CaptureFixture[str]) -> None:
-    sys.argv = argv("tests/data/PPN750717092-00000780.ocr.xml -c")
+    sys.argv = argv(os.path.join(datadir, "PPN750717092-00000780.ocr.xml") + " -c")
     alto_tools.main()
     assert "Confidence: 78.29" in capsys.readouterr().out
 
 
 def test_multi_files_confidence(capsys: pytest.CaptureFixture[str]) -> None:
-    sys.argv = argv("-c tests/")
+    sys.argv = argv("-c " + os.path.dirname(datadir))
     alto_tools.main()
     stdout = capsys.readouterr().out
     assert "Confidence: 78.29" in stdout
@@ -78,13 +78,13 @@ def test_multi_files_confidence(capsys: pytest.CaptureFixture[str]) -> None:
 
 
 def test_single_file_stats(capsys: pytest.CaptureFixture[str]) -> None:
-    sys.argv = argv("-s tests/data/PPN750717092-00000780.ocr.xml")
+    sys.argv = argv("-s " + os.path.join(datadir, "PPN750717092-00000780.ocr.xml"))
     alto_tools.main()
     assert "# of <TextLine> elements: 60" in capsys.readouterr().out
 
 
 def test_single_file_text_extraction(capsys: pytest.CaptureFixture[str]) -> None:
-    sys.argv = argv("-t tests/data/PPN750717092-00000780.ocr.xml")
+    sys.argv = argv("-t " + os.path.join(datadir, "PPN750717092-00000780.ocr.xml"))
     alto_tools.main()
     assert (
         "Thüren, Lieferung der erforderlichen Gerüste und"
@@ -92,13 +92,13 @@ def test_single_file_text_extraction(capsys: pytest.CaptureFixture[str]) -> None
 
 
 def test_single_file_illustration_coords(capsys: pytest.CaptureFixture[str]) -> None:
-    sys.argv = argv("-i tests/data/PPN720183197-PHYS_0004.xml")
+    sys.argv = argv("-i " + os.path.join(datadir, "PPN720183197-PHYS_0004.xml"))
     alto_tools.main()
     assert "Illustration: block_20=201,321,61,226" in capsys.readouterr().out
 
 
 def test_single_file_graphic_coords(capsys: pytest.CaptureFixture[str]) -> None:
-    sys.argv = argv("-g tests/data/PPN750717092-00000780.ocr.xml")
+    sys.argv = argv("-g " + os.path.join(datadir, "PPN750717092-00000780.ocr.xml"))
     alto_tools.main()
     assert "GraphicalElement: Page1_Block29=11,899,2983,549" in capsys.readouterr().out
 


### PR DESCRIPTION
In #16, there was a discussion on whether and how to use `@SUBS_CONTENT`, if any. It turned out in favour of always directly producing the unaltered strings. (So the conditional in the code could already have been removed.)

However, what was missing – in both cases, with and without `@SUBS_CONTENT`, before and after https://github.com/cneud/alto-tools/commit/c6b0a5d9cc193b3847add78ca4a922b7e0670ce6 – was to actually include the hyphen character itself. (It was also missing before that change for the case where no `SUBS_CONTENT` was annotated.)

I extended the tests to use the second included example file, which does contain both plain hyphens (directly part of the word) and `HYP` elements.

The latter also showcases a problem: if `HYP/@CONTENT` is soft hyphen (U+00AD), then the output might not be what we want. Hence I made a second commit which normalises all hyphens to ASCII hyphen-minus (U+002D).